### PR TITLE
Fixes for `re` module bugs and other minor differences from CPython

### DIFF
--- a/adafruit_templateengine.py
+++ b/adafruit_templateengine.py
@@ -156,8 +156,11 @@ _PRECOMPILED_EXTENDS_PATTERN = re.compile(r"{% extends '.+?' %}|{% extends \".+?
 _PRECOMPILED_BLOCK_PATTERN = re.compile(r"{% block \w+? %}")
 _PRECOMPILED_INCLUDE_PATTERN = re.compile(r"{% include '.+?' %}|{% include \".+?\" %}")
 _PRECOMPILED_HASH_COMMENT_PATTERN = re.compile(r"{# .+? #}")
+# Workaround for bug in re module https://github.com/adafruit/circuitpython/issues/8525
 _PRECOMPILED_BLOCK_COMMENT_PATTERN = re.compile(
-    r"{% comment ('.*?' |\".*?\" )?%}[\s\S]*?{% endcomment %}"
+    # TODO: Use r"{% comment ('.*?' |\".*?\" )?%}[\s\S]*?{% endcomment %}" without flags when fixed
+    r"{% comment ('.*?' |\".*?\" )?%}.*?{% endcomment %}",
+    16,  # re.DOTALL flag
 )
 _PRECOMPILED_TOKEN_PATTERN = re.compile(r"{{ .+? }}|{% .+? %}")
 

--- a/adafruit_templateengine.py
+++ b/adafruit_templateengine.py
@@ -192,7 +192,7 @@ def _resolve_includes(template: str):
         # TODO: Restrict include to specific directory
 
         if not _exists_and_is_file(template_path):
-            raise FileNotFoundError(f"Include template not found: {template_path}")
+            raise OSError(f"Include template not found: {template_path}")
 
         # Replace the include with the template content
         with open(template_path, "rt", encoding="utf-8") as template_file:

--- a/adafruit_templateengine.py
+++ b/adafruit_templateengine.py
@@ -357,7 +357,7 @@ def _create_template_function(  # pylint: disable=,too-many-locals,too-many-bran
     function_string = f"def {function_name}({context_name}):\n"
     indent, indentation_level = "    ", 1
 
-    # Keep track of the tempalte state
+    # Keep track of the template state
     forloop_iterables: "list[str]" = []
     autoescape_modes: "list[bool]" = ["default_on"]
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -140,13 +140,13 @@ and then include it in multiple pages.
 
 .. literalinclude:: ../examples/footer.html
     :caption: examples/footer.html
-    :lines: 5-
+    :lines: 7-
     :language: html
     :linenos:
 
 .. literalinclude:: ../examples/base_without_footer.html
     :caption: examples/base_without_footer.html
-    :lines: 5-
+    :lines: 7-
     :language: html
     :emphasize-lines: 12
     :linenos:
@@ -173,13 +173,13 @@ This allows sharing whole layout, not only single parts.
 
 .. literalinclude:: ../examples/child.html
     :caption: examples/child.html
-    :lines: 5-
+    :lines: 7-
     :language: html
     :linenos:
 
 .. literalinclude:: ../examples/parent_layout.html
     :caption: examples/parent_layout.html
-    :lines: 5-
+    :lines: 7-
     :language: html
     :linenos:
 
@@ -196,7 +196,7 @@ Executing Python code in templates
 ----------------------------------
 
 It is also possible to execute Python code in templates.
-This an be used for e.g. defining variables, modifying context, or breaking from loops.
+This can be used for e.g. defining variables, modifying context, or breaking from loops.
 
 
 .. literalinclude:: ../examples/templateengine_exec.py
@@ -221,7 +221,7 @@ Supported comment syntaxes:
 
 .. literalinclude:: ../examples/comments.html
     :caption: examples/comments.html
-    :lines: 5-
+    :lines: 7-
     :language: html
     :linenos:
 
@@ -247,7 +247,7 @@ and in all ``Template`` constructors.
 
 .. literalinclude:: ../examples/autoescape.html
     :caption: examples/autoescape.html
-    :lines: 5-
+    :lines: 7-
     :language: html
     :linenos:
 

--- a/examples/autoescape.html
+++ b/examples/autoescape.html
@@ -1,6 +1,8 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 Michał Pokusa
-#
-# SPDX-License-Identifier: Unlicense
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2023 Michał Pokusa
+
+SPDX-License-Identifier: Unlicense
+-->
 
 <!DOCTYPE html>
 <html>

--- a/examples/base_without_footer.html
+++ b/examples/base_without_footer.html
@@ -1,6 +1,8 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 Michał Pokusa
-#
-# SPDX-License-Identifier: Unlicense
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2023 Michał Pokusa
+
+SPDX-License-Identifier: Unlicense
+-->
 
 <!DOCTYPE html>
 <html>

--- a/examples/child.html
+++ b/examples/child.html
@@ -1,6 +1,8 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 Michał Pokusa
-#
-# SPDX-License-Identifier: Unlicense
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2023 Michał Pokusa
+
+SPDX-License-Identifier: Unlicense
+-->
 
 {% extends "./examples/parent_layout.html" %}
 

--- a/examples/comments.html
+++ b/examples/comments.html
@@ -1,6 +1,8 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 Michał Pokusa
-#
-# SPDX-License-Identifier: Unlicense
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2023 Michał Pokusa
+
+SPDX-License-Identifier: Unlicense
+-->
 
 <!DOCTYPE html>
 <html>

--- a/examples/footer.html
+++ b/examples/footer.html
@@ -1,6 +1,8 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 Michał Pokusa
-#
-# SPDX-License-Identifier: Unlicense
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2023 Michał Pokusa
+
+SPDX-License-Identifier: Unlicense
+-->
 
 <footer>
     Reusable footer that can be included in multiple pages

--- a/examples/parent_layout.html
+++ b/examples/parent_layout.html
@@ -1,6 +1,8 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 Michał Pokusa
-#
-# SPDX-License-Identifier: Unlicense
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2023 Michał Pokusa
+
+SPDX-License-Identifier: Unlicense
+-->
 
 <!DOCTYPE html>
 <html>

--- a/examples/templateengine_exec.py
+++ b/examples/templateengine_exec.py
@@ -26,8 +26,8 @@ template = r"""
         And reverse-sorted: {{ name }}</br>
 
         {% for letter in name %}
-            {% if letter!="a" %}
-                {% if letter=="k" %}
+            {% if letter != "a" %}
+                {% if letter == "k" %}
                     Skip a letter... e.g. "{{ letter }}"</br>
                     {% exec continue %}
                 {% endif %}

--- a/examples/templateengine_exec.py
+++ b/examples/templateengine_exec.py
@@ -16,7 +16,7 @@ template = r"""
         {% exec name = "jake" %}
         We defined a name: {{ name }}</br>
 
-        {% exec name = name.title() %}
+        {% exec name = (name[0].upper() + name[1:]) if name else "" %}
         First letter was capitalized: {{ name }}</br>
 
         {% exec name = list(name) %}


### PR DESCRIPTION
🪛Fixes:

- Library used `FileNotFoundError`, which is not present in CircuitPython
- One of example used `str.title()` which is not present in CircuitPython
- Some parts of the code were still vulnerable to [bug](https://github.com/adafruit/circuitpython/issues/6860) in `re` module that incorrectly detected positions of unicode characters
- There is another [bug](https://github.com/adafruit/circuitpython/issues/8525) in `re` module, that incorrectly matches `[\s\S]` pattern, so it had to be changed to something that does the same thing, using other tokens

Last two ones should be a temporary solution, until the bugs are fixed, but for now they are necessary.

🏗️ Refactor:

- EDIT1: Changed hash comment in `.html` files to HTML comments

Additional testing would be highly appreciated. 😃