### PR TITLE
Syntax error prevention and traceback readability

### DIFF
--- a/adafruit_templateengine.py
+++ b/adafruit_templateengine.py
@@ -366,13 +366,13 @@ def _token_is_on_own_line(text_before_token: str) -> bool:
     return _LSTRIP_BLOCK_PATTERN.search(text_before_token) is not None
 
 
-def _create_template_function(  # pylint: disable=,too-many-locals,too-many-branches,too-many-statements
+def _create_template_rendering_function(  # pylint: disable=,too-many-locals,too-many-branches,too-many-statements
     template: str,
     language: str = Language.HTML,
     *,
     trim_blocks: bool = True,
     lstrip_blocks: bool = True,
-    function_name: str = "_",
+    function_name: str = "__template_rendering_function",
     context_name: str = "context",
     dry_run: bool = False,
 ) -> "Generator[str] | str":
@@ -605,7 +605,9 @@ class Template:
         :param str template_string: String containing the template to be rendered
         :param str language: Language for autoescaping. Defaults to HTML
         """
-        self._template_function = _create_template_function(template_string, language)
+        self._template_function = _create_template_rendering_function(
+            template_string, language
+        )
 
     def render_iter(
         self, context: dict = None, *, chunk_size: int = None

--- a/adafruit_templateengine.py
+++ b/adafruit_templateengine.py
@@ -521,12 +521,10 @@ def _create_template_function(  # pylint: disable=,too-many-locals,too-many-bran
                 nested_autoescape_modes.pop()
 
             else:
-                raise ValueError(
-                    f"Unknown token type: {token} at {token_match.start()}"
-                )
+                raise SyntaxError(f"Unknown token type: {token}")
 
         else:
-            raise ValueError(f"Unknown token type: {token} at {token_match.start()}")
+            raise SyntaxError(f"Unknown token type: {token}")
 
         # Continue with the rest of the template
         template = template[token_match.end() :]

--- a/adafruit_templateengine.py
+++ b/adafruit_templateengine.py
@@ -219,7 +219,7 @@ def _resolve_includes(template: str):
 
 def _check_for_unsupported_nested_blocks(template: str):
     if _find_block(template) is not None:
-        raise ValueError("Nested blocks are not supported")
+        raise SyntaxError("Nested blocks are not supported")
 
 
 def _resolve_includes_blocks_and_extends(template: str):
@@ -248,7 +248,7 @@ def _resolve_includes_blocks_and_extends(template: str):
             endblock_match = _find_named_endblock(template, block_name)
 
             if endblock_match is None:
-                raise ValueError(r"Missing {% endblock %} for block: " + block_name)
+                raise SyntaxError("Missing {% endblock %} for block: " + block_name)
 
             block_content = template[block_match.end() : endblock_match.start()]
 
@@ -457,7 +457,7 @@ def _create_template_rendering_function(  # pylint: disable=,too-many-locals,too
                 indentation_level -= 1
 
                 if not nested_if_statements:
-                    raise SyntaxError("No matching {% if ... %} block for {% endif %}")
+                    raise SyntaxError("Missing {% if ... %} block for {% endif %}")
 
                 nested_if_statements.pop()
 
@@ -479,9 +479,7 @@ def _create_template_rendering_function(  # pylint: disable=,too-many-locals,too
                 indentation_level -= 1
 
                 if not nested_for_loops:
-                    raise SyntaxError(
-                        "No matching {% for ... %} block for {% endfor %}"
-                    )
+                    raise SyntaxError("Missing {% for ... %} block for {% endfor %}")
 
                 nested_for_loops.pop()
 
@@ -496,7 +494,7 @@ def _create_template_rendering_function(  # pylint: disable=,too-many-locals,too
 
                 if not nested_while_loops:
                     raise SyntaxError(
-                        "No matching {% while ... %} block for {% endwhile %}"
+                        "Missing {% while ... %} block for {% endwhile %}"
                     )
 
                 nested_while_loops.pop()
@@ -517,7 +515,7 @@ def _create_template_rendering_function(  # pylint: disable=,too-many-locals,too
             elif token == r"{% endautoescape %}":
                 if not nested_autoescape_modes:
                     raise SyntaxError(
-                        "No matching {% autoescape ... %} block for {% endautoescape %}"
+                        "Missing {% autoescape ... %} block for {% endautoescape %}"
                     )
 
                 nested_autoescape_modes.pop()
@@ -534,15 +532,15 @@ def _create_template_rendering_function(  # pylint: disable=,too-many-locals,too
     # Checking for unclosed blocks
     if len(nested_if_statements) > 0:
         last_if_statement = nested_if_statements[-1]
-        raise SyntaxError(f"Missing {{% endif %}} for {last_if_statement}")
+        raise SyntaxError("Missing {% endif %} for " + last_if_statement)
 
     if len(nested_for_loops) > 0:
         last_for_loop = nested_for_loops[-1]
-        raise SyntaxError(f"Missing {{% endfor %}} for {last_for_loop}")
+        raise SyntaxError("Missing {% endfor %} for " + last_for_loop)
 
     if len(nested_while_loops) > 0:
         last_while_loop = nested_while_loops[-1]
-        raise SyntaxError(f"Missing {{% endwhile %}} for {last_while_loop}")
+        raise SyntaxError("Missing {% endwhile %} for " + last_while_loop)
 
     # No check for unclosed autoescape blocks, as they are optional and do not result in errors
 

--- a/adafruit_templateengine.py
+++ b/adafruit_templateengine.py
@@ -407,10 +407,12 @@ def _create_template_function(  # pylint: disable=,too-many-locals,too-many-bran
                 if last_token_was_block and text_before_token.startswith("\n"):
                     text_before_token = text_before_token[1:]
 
-            if text_before_token:
-                function_string += (
-                    indent * indentation_level + f"yield {repr(text_before_token)}\n"
-                )
+        if text_before_token:
+            function_string += (
+                indent * indentation_level + f"yield {repr(text_before_token)}\n"
+            )
+        else:
+            function_string += indent * indentation_level + "pass\n"
 
         # Token is an expression
         if token.startswith(r"{{ "):


### PR DESCRIPTION
Overall this PR makes it easier to not make mistakes when writing templates, as it will raise error  in more cases instead of silently allowing bad syntax that will result in unexpected rendered string.

💥 Breaking changes:

- May throw error on templates where previously it silently allowed bad syntax or raised unhandled exceptions e.g.
```django
<!DOCTYPE html>
<html>
    <body>
        {% if context.get("condition") %}{% endif %}

        {% for items in context.get("items") %}
        
        {% endwhile %}
        {% endwhile %}
    </body>
</html>
```

Now it will expicitly say what is wrong, e.g. `SyntaxError: Missing {% while ... %} block for {% endwhile %}`

🛠️ Updated/Changed:

- Default name of template rendering function is now more verbose, thus making traceback more readable
- `Template` constructor will raise error if provided template is incorrect e.g. has unclosed `if`, `for` or `while`
- `_create_template_rendering_function` automatically adds `pass` where it might be needed, e.g. when someone puts empty loop where the ending token is right after the starting one

🏗️ Refactor:

- Some `ValueError`s for bad template syntrax are now `SyntaxError`s