### PR TITLE
Fixes for render functions `chunk_size` parameter and negative skipped linesin error message

### DIFF
--- a/adafruit_templateengine.py
+++ b/adafruit_templateengine.py
@@ -99,11 +99,11 @@ class TemplateSyntaxError(SyntaxError):
             )
 
             if 0 < top_skipped_lines:
-                before_skipped_lines_message = cls._skipped_lines_message(
+                top_skipped_lines_message = cls._skipped_lines_message(
                     top_skipped_lines
                 )
                 template_before_token = (
-                    f"{before_skipped_lines_message}\n{template_before_token}"
+                    f"{top_skipped_lines_message}\n{template_before_token}"
                 )
 
         template_after_token = token.template[token.end_position :]
@@ -113,11 +113,11 @@ class TemplateSyntaxError(SyntaxError):
             )
 
             if 0 < bottom_skipped_lines:
-                after_skipped_lines_message = cls._skipped_lines_message(
+                bottom_skipped_lines_message = cls._skipped_lines_message(
                     bottom_skipped_lines
                 )
                 template_after_token = (
-                    f"{template_after_token}\n{after_skipped_lines_message}"
+                    f"{template_after_token}\n{bottom_skipped_lines_message}"
                 )
 
         lines_before_line_with_token = template_before_token.rsplit("\n", 1)[0]

--- a/adafruit_templateengine.py
+++ b/adafruit_templateengine.py
@@ -94,17 +94,21 @@ class TemplateSyntaxError(SyntaxError):
 
         template_before_token = token.template[: token.start_position]
         if skipped_lines := template_before_token.count("\n") - lines_around:
-            template_before_token = (
-                f"{cls._skipped_lines_message(skipped_lines)}\n"
-                + "\n".join(template_before_token.split("\n")[-(lines_around + 1) :])
+            template_before_token = "\n".join(
+                template_before_token.split("\n")[-(lines_around + 1) :]
             )
+
+            if 0 < skipped_lines:
+                template_before_token = f"{cls._skipped_lines_message(skipped_lines)}\n{template_before_token}"
 
         template_after_token = token.template[token.end_position :]
         if skipped_lines := template_after_token.count("\n") - lines_around:
-            template_after_token = (
-                "\n".join(template_after_token.split("\n")[: (lines_around + 1)])
-                + f"\n{cls._skipped_lines_message(skipped_lines)}"
+            template_after_token = "\n".join(
+                template_after_token.split("\n")[: (lines_around + 1)]
             )
+
+            if 0 < skipped_lines:
+                template_after_token += f"\n{cls._skipped_lines_message(skipped_lines)}"
 
         lines_before_line_with_token = template_before_token.rsplit("\n", 1)[0]
 
@@ -122,7 +126,7 @@ class TemplateSyntaxError(SyntaxError):
 
         lines_after_line_with_token = template_after_token.split("\n", 1)[-1]
 
-        return "\n".join(
+        return "\n" + "\n".join(
             [
                 lines_before_line_with_token,
                 line_with_token,

--- a/adafruit_templateengine.py
+++ b/adafruit_templateengine.py
@@ -804,18 +804,14 @@ def render_string_iter(
     key = hash(template_string)
 
     if cache and key in _CACHE:
-        return _yield_as_sized_chunks(
-            _CACHE[key].render_iter(context or {}, chunk_size), chunk_size
-        )
+        return _CACHE[key].render_iter(context or {}, chunk_size=chunk_size)
 
     template = Template(template_string)
 
     if cache:
         _CACHE[key] = template
 
-    return _yield_as_sized_chunks(
-        template.render_iter(context or {}), chunk_size=chunk_size
-    )
+    return template.render_iter(context or {}, chunk_size=chunk_size)
 
 
 def render_string(
@@ -882,18 +878,14 @@ def render_template_iter(
     key = hash(template_path)
 
     if cache and key in _CACHE:
-        return _yield_as_sized_chunks(
-            _CACHE[key].render_iter(context or {}, chunk_size), chunk_size
-        )
+        return _CACHE[key].render_iter(context or {}, chunk_size=chunk_size)
 
     template = FileTemplate(template_path)
 
     if cache:
         _CACHE[key] = template
 
-    return _yield_as_sized_chunks(
-        template.render_iter(context or {}, chunk_size=chunk_size), chunk_size
-    )
+    return template.render_iter(context or {}, chunk_size=chunk_size)
 
 
 def render_template(

--- a/adafruit_templateengine.py
+++ b/adafruit_templateengine.py
@@ -771,7 +771,7 @@ class FileTemplate(Template):
         super().__init__(template_string)
 
 
-_CACHE: "dict[int, Template| FileTemplate]" = {}
+CACHED_TEMPLATES: "dict[int, Template| FileTemplate]" = {}
 
 
 def render_string_iter(
@@ -803,13 +803,13 @@ def render_string_iter(
     """
     key = hash(template_string)
 
-    if cache and key in _CACHE:
-        return _CACHE[key].render_iter(context or {}, chunk_size=chunk_size)
+    if cache and key in CACHED_TEMPLATES:
+        return CACHED_TEMPLATES[key].render_iter(context or {}, chunk_size=chunk_size)
 
     template = Template(template_string)
 
     if cache:
-        _CACHE[key] = template
+        CACHED_TEMPLATES[key] = template
 
     return template.render_iter(context or {}, chunk_size=chunk_size)
 
@@ -837,13 +837,13 @@ def render_string(
     """
     key = hash(template_string)
 
-    if cache and key in _CACHE:
-        return _CACHE[key].render(context or {})
+    if cache and key in CACHED_TEMPLATES:
+        return CACHED_TEMPLATES[key].render(context or {})
 
     template = Template(template_string)
 
     if cache:
-        _CACHE[key] = template
+        CACHED_TEMPLATES[key] = template
 
     return template.render(context or {})
 
@@ -877,13 +877,13 @@ def render_template_iter(
     """
     key = hash(template_path)
 
-    if cache and key in _CACHE:
-        return _CACHE[key].render_iter(context or {}, chunk_size=chunk_size)
+    if cache and key in CACHED_TEMPLATES:
+        return CACHED_TEMPLATES[key].render_iter(context or {}, chunk_size=chunk_size)
 
     template = FileTemplate(template_path)
 
     if cache:
-        _CACHE[key] = template
+        CACHED_TEMPLATES[key] = template
 
     return template.render_iter(context or {}, chunk_size=chunk_size)
 
@@ -912,12 +912,12 @@ def render_template(
 
     key = hash(template_path)
 
-    if cache and key in _CACHE:
-        return _CACHE[key].render(context or {})
+    if cache and key in CACHED_TEMPLATES:
+        return CACHED_TEMPLATES[key].render(context or {})
 
     template = FileTemplate(template_path)
 
     if cache:
-        _CACHE[key] = template
+        CACHED_TEMPLATES[key] = template
 
     return template.render(context or {})

--- a/adafruit_templateengine.py
+++ b/adafruit_templateengine.py
@@ -93,22 +93,32 @@ class TemplateSyntaxError(SyntaxError):
         """
 
         template_before_token = token.template[: token.start_position]
-        if skipped_lines := template_before_token.count("\n") - lines_around:
+        if top_skipped_lines := template_before_token.count("\n") - lines_around:
             template_before_token = "\n".join(
                 template_before_token.split("\n")[-(lines_around + 1) :]
             )
 
-            if 0 < skipped_lines:
-                template_before_token = f"{cls._skipped_lines_message(skipped_lines)}\n{template_before_token}"
+            if 0 < top_skipped_lines:
+                before_skipped_lines_message = cls._skipped_lines_message(
+                    top_skipped_lines
+                )
+                template_before_token = (
+                    f"{before_skipped_lines_message}\n{template_before_token}"
+                )
 
         template_after_token = token.template[token.end_position :]
-        if skipped_lines := template_after_token.count("\n") - lines_around:
+        if bottom_skipped_lines := template_after_token.count("\n") - lines_around:
             template_after_token = "\n".join(
                 template_after_token.split("\n")[: (lines_around + 1)]
             )
 
-            if 0 < skipped_lines:
-                template_after_token += f"\n{cls._skipped_lines_message(skipped_lines)}"
+            if 0 < bottom_skipped_lines:
+                after_skipped_lines_message = cls._skipped_lines_message(
+                    bottom_skipped_lines
+                )
+                template_after_token = (
+                    f"{template_after_token}\n{after_skipped_lines_message}"
+                )
 
         lines_before_line_with_token = template_before_token.rsplit("\n", 1)[0]
 


### PR DESCRIPTION
🪛Fixes:

- Removed unnecessary `_yield_as_sized_chunks` in `render_...` functions
- Added check for skipped lines in `TemplateSyntaxError` to avoid messages like `"[-1 lines skipped]"`

🏗️ Refactor:

- Renamed `_CACHE` to `CACHED_TEMPLATES`
