### PR TITLE
Fix: Python 3.13 optimized scope `locals` with `exec`

### DIFF
--- a/adafruit_templateengine.py
+++ b/adafruit_templateengine.py
@@ -655,8 +655,10 @@ def _create_template_rendering_function(
         function_def += indented('yield ""')
 
     # Create and return the template function
-    exec(function_def)
-    return locals()[function_name]
+    _globals = {"safe_html": safe_html}
+    _locals = {}
+    exec(function_def, _globals, _locals)
+    return _locals[function_name]
 
 
 def _yield_as_sized_chunks(generator: "Generator[str]", chunk_size: int) -> "Generator[str]":


### PR DESCRIPTION
🪛Fixes:

- From Python 3.13 calling `exec` does not implicitly update `locals()` which **always** results in `KeyError`, regardless of the template content. To retain current behavior it is necessary to pass a manually created dict, which is also a recommended way of doing this

Related links:
https://docs.python.org/3/whatsnew/3.13.html#defined-mutation-semantics-for-locals
https://peps.python.org/pep-0667/